### PR TITLE
Switch to example spider from Frontera source code

### DIFF
--- a/bc/spiders/bc.py
+++ b/bc/spiders/bc.py
@@ -1,20 +1,25 @@
 # -*- coding: utf-8 -*-
-from scrapy.exceptions import DontCloseSpider
+from scrapy.spider import Spider
+from scrapy.http import Request
+from scrapy.http.response.html import HtmlResponse
 from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
-from scrapy import signals
 
 
-class BCSpider(CrawlSpider):
+class BCSpider(Spider):
     name = 'bc'
-
-    rules = (
-       Rule(LinkExtractor(), follow=True),
-    )
 
     def __init__(self, *args, **kwargs):
         super(BCSpider, self).__init__(*args, **kwargs)
-        self._follow_links = True
+        self.le = LinkExtractor()
+
+    def parse(self, response):
+        if not isinstance(response, HtmlResponse):
+            return
+
+        for link in self.le.extract_links(response):
+            r = Request(url=link.url)
+            r.meta.update(link_text=link.text)
+            yield r
 
     @classmethod
     def from_crawler(cls, crawler, *args, **kwargs):


### PR DESCRIPTION
I was getting the following error with the existing spider when running the example. The seed url was http://www.example.com.

```
2016-09-24 21:12:57 [scrapy] DEBUG: Crawled (200) <GET http://www.iana.org/domains/reserved> (referer: None)
2016-09-24 21:12:57 [scrapy] ERROR: Spider error processing <GET http://www.iana.org/domains/reserved> (referer: None)
Traceback (most recent call last):
  File "/Users/csmith/.pyenv/versions/3.5.2/envs/hermes-3.5.2/lib/python3.5/site-packages/twisted/internet/defer.py", line 587, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/Users/csmith/.pyenv/versions/3.5.2/envs/hermes-3.5.2/lib/python3.5/site-packages/scrapy/spiders/crawl.py", line 67, in _response_downloaded
    rule = self._rules[response.meta['rule']]
KeyError: 'rule'
```

Copying the example spider from the frontera source code stopped this error from occurring.
